### PR TITLE
Adding in s3 support for loading/saving the score file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 slackclient>=1.1,<2
+boto3>=1.5,<2

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     packages=["plusplusbot"],
     install_requires=[
         "slackclient>=1.1,<2",
+        "boto3>=1.5,<2"
     ],
     python_requires="~=3.5",
     extras_require={


### PR DESCRIPTION
Doesn't add support for manually providing credentials, we assume the user has either set the appropriate env vars, or let boto3 figure it out (instance role)