### PR TITLE
Add in user override functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,7 @@ ENV/
 
 # vim
 *.swp
+
+# emojirades testing config
+scores.csv
+state.json

--- a/plusplusbot/command/commands.py
+++ b/plusplusbot/command/commands.py
@@ -32,7 +32,35 @@ class Command(ABC):
         }
 
     def prepare_args(self, event):
-        pass
+        self.args["channel"] = event["channel"]
+        self.args["user"] = event["user"]
+
+        extra_args = [
+            "[\\s]*(player=[\\s]*(<@(?P<user_override>[0-9A-Z]+)>))*",
+        ]
+
+        pattern = self.pattern + ''.join(extra_args)
+
+        if "{me}" in pattern:
+            pattern = pattern.format(me=self.slack.bot_id)
+
+        print(pattern)
+        match = re.match(pattern, event["text"])
+
+        if hasattr(match, "groupdict"):
+            self.args.update(match.groupdict())
+
+        if self.args.get("user_override") and self.gamestate.is_admin(self.args["channel"], self.args["user"]):
+            self.args["original_user"] = self.args["user"]
+            self.args["user"] = self.args["user_override"]
+
+    def execute(self):
+        if self.args.get("original_user"):
+            shadow_user = " (aka <@{0}>)".format(self.args["original_user"])
+        else:
+            shadow_user = ""
+
+        yield (None, "This action was performed by <@{0}>{1}".format(self.args["user"], shadow_user))
 
     @classmethod
     def match(cls, text, **kwargs):
@@ -44,10 +72,6 @@ class Command(ABC):
 
     @abstractproperty
     def description(self):
-        pass
-
-    @abstractmethod
-    def execute(self):
         pass
 
     def __str__(self):

--- a/plusplusbot/command/gamestate_commands/correct_guess_command.py
+++ b/plusplusbot/command/gamestate_commands/correct_guess_command.py
@@ -5,7 +5,7 @@ import random
 
 
 class CorrectGuess(GameStateCommand):
-    pattern = "<@(?P<target_user>[0-9A-Z]+)>[\s]*\+\+"
+    pattern = r"<@(?P<target_user>[0-9A-Z]+)>[\s]*\+\+"
     description = "Indicates the player has correctly guessed (manually awarded)!"
     first_emojis = [
         ":tada:",

--- a/plusplusbot/command/gamestate_commands/correct_guess_command.py
+++ b/plusplusbot/command/gamestate_commands/correct_guess_command.py
@@ -2,11 +2,10 @@ from plusplusbot.command.gamestate_commands.gamestate_command import GameStateCo
 from plusplusbot.wrappers import only_actively_guessing
 
 import random
-import re
 
 
 class CorrectGuess(GameStateCommand):
-    pattern = "<@([0-9A-Z]+)>[\s]*\+\+"
+    pattern = "<@(?P<target_user>[0-9A-Z]+)>[\s]*\+\+"
     description = "Indicates the player has correctly guessed (manually awarded)!"
     first_emojis = [
         ":tada:",
@@ -21,12 +20,13 @@ class CorrectGuess(GameStateCommand):
         super().__init__(*args, **kwargs)
 
     def prepare_args(self, event):
-        self.args["target_user"] = re.match(self.pattern, event["text"]).group(1)
-        self.args["channel"] = event["channel"]
-        self.args["user"] = event["user"]
+        super().prepare_args(event)
 
     @only_actively_guessing
     def execute(self):
+        for i in super().execute():
+            yield i
+
         state = self.gamestate.state[self.args["channel"]]
 
         if self.args["target_user"] in (state["old_winner"], state["winner"]):

--- a/plusplusbot/command/gamestate_commands/game_status.py
+++ b/plusplusbot/command/gamestate_commands/game_status.py
@@ -1,5 +1,3 @@
-import re
-
 from plusplusbot.command.gamestate_commands.gamestate_command import GameStateCommand
 from plusplusbot.wrappers import admin_check
 
@@ -12,22 +10,30 @@ class GameStatus(GameStateCommand):
         super().__init__(*args, **kwargs)
 
     def prepare_args(self, event):
-        self.args["user"] = event["user"]
-        self.args["channel"] = event["channel"]
+        super().prepare_args(event)
 
     @admin_check
     def execute(self):
+        for i in super().execute():
+            yield i
+
         status = self.gamestate.game_status(self.args["channel"])
 
         pretty_status = []
 
         for k, v in sorted(status.items()):
             if k == "old_winner" or k == "winner":
-                v = "<@{0}>".format(v)
+                if v is None:
+                    v = "Not Set"
+                else:
+                    v = "<@{0}>".format(v)
             elif k == "admins":
                 v = ", ".join(["<@{0}>".format(i) for i in v])
             elif k == "emojirade":
-                v = "`{0}`".format(v)
+                if v is None:
+                    v = "Not Set"
+                else:
+                    v = "`{0}`".format(v)
             else:
                 v = str(v)
 

--- a/plusplusbot/command/gamestate_commands/gamestate_command.py
+++ b/plusplusbot/command/gamestate_commands/gamestate_command.py
@@ -4,3 +4,10 @@ from plusplusbot.command.commands import Command
 class GameStateCommand(Command):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    def prepare_args(self, event):
+        super().prepare_args(event)
+
+    def execute(self):
+        for i in super().execute():
+            yield i

--- a/plusplusbot/command/gamestate_commands/inferred_correct_guess_command.py
+++ b/plusplusbot/command/gamestate_commands/inferred_correct_guess_command.py
@@ -10,12 +10,14 @@ class InferredCorrectGuess(GameStateCommand):
         super().__init__(*args, **kwargs)
 
     def prepare_args(self, event):
+        super().prepare_args(event)
         self.args["target_user"] = event["user"]
-        self.args["channel"] = event["channel"]
-        self.args["user"] = event["user"]
 
     @only_actively_guessing
     def execute(self):
+        for i in super().execute():
+            yield i
+
         state = self.gamestate.state[self.args["channel"]]
 
         self.gamestate.correct_guess(self.args["channel"], self.args["target_user"])

--- a/plusplusbot/command/gamestate_commands/inferred_correct_guess_command.py
+++ b/plusplusbot/command/gamestate_commands/inferred_correct_guess_command.py
@@ -11,7 +11,7 @@ class InferredCorrectGuess(GameStateCommand):
 
     def prepare_args(self, event):
         super().prepare_args(event)
-        self.args["target_user"] = event["user"]
+        self.args["target_user"] = self.args["user"]
 
     @only_actively_guessing
     def execute(self):

--- a/plusplusbot/command/gamestate_commands/newgame_command.py
+++ b/plusplusbot/command/gamestate_commands/newgame_command.py
@@ -1,27 +1,22 @@
 from plusplusbot.command.gamestate_commands.gamestate_command import GameStateCommand
 from plusplusbot.wrappers import admin_check
 
-import re
-
 
 class NewGame(GameStateCommand):
-    pattern = "<@{me}> new game <@([0-9A-Z]+)> <@([0-9A-Z]+)>"
+    pattern = "<@{me}> new game <@(?P<old_winner>[0-9A-Z]+)> <@(?P<winner>[0-9A-Z]+)>"
     description = "Initiate a new game by setting the Old Winner and the Winner"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def prepare_args(self, event):
-        rendered_pattern = self.pattern.format(me=self.slack.bot_id)
-        match = re.match(rendered_pattern, event["text"])
-
-        self.args["user"] = event["user"]
-        self.args["channel"] = event["channel"]
-        self.args["old_winner"] = match.group(1)
-        self.args["winner"] = match.group(2)
+        super().prepare_args(event)
 
     @admin_check
     def execute(self):
+        for i in super().execute():
+            yield i
+
         if self.args["winner"] == self.args["old_winner"]:
             yield (None, "Sorry, but the old and current winner cannot be the same person (<@{winner}>)...".format(**self.args))
             raise StopIteration

--- a/plusplusbot/command/gamestate_commands/remove_admin_command.py
+++ b/plusplusbot/command/gamestate_commands/remove_admin_command.py
@@ -1,26 +1,23 @@
 from plusplusbot.command.gamestate_commands.gamestate_command import GameStateCommand
 from plusplusbot.wrappers import admin_check
 
-import re
-
 
 class RemoveAdmin(GameStateCommand):
-    pattern = "<@{me}> demote <@([0-9A-Z]+)>"
+    pattern = "<@{me}> demote <@(?P<admin>[0-9A-Z]+)>"
     description = "Removes a user from the admins group"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def prepare_args(self, event):
-        self.args["user"] = event["user"]
-        self.args["channel"] = event["channel"]
-
-        rendered_pattern = self.pattern.format(me=self.slack.bot_id)
-        self.args["admin"] = re.match(rendered_pattern, event["text"]).group(1)
+        super().prepare_args(event)
 
     @admin_check
     def execute(self):
+        for i in super().execute():
+            yield i
+
         if self.gamestate.remove_admin(self.args["channel"], self.args["admin"]):
-            yield (None, "<@{user}> has demoted <@{admin}> to a pleb :cold_sweat:".format(**self.args))
+            yield (None, "<@{admin}> has been demoted to a pleb :cold_sweat:".format(**self.args))
         else:
             yield (None, "<@{admin}> isn't an admin :face_with_rolling_eyes:".format(**self.args))

--- a/plusplusbot/command/gamestate_commands/set_admin_command.py
+++ b/plusplusbot/command/gamestate_commands/set_admin_command.py
@@ -1,26 +1,23 @@
 from plusplusbot.command.gamestate_commands.gamestate_command import GameStateCommand
 from plusplusbot.wrappers import admin_check
 
-import re
-
 
 class SetAdmin(GameStateCommand):
-    pattern = "<@{me}> promote <@([0-9A-Z]+)>"
+    pattern = "<@{me}> promote <@(?P<admin>[0-9A-Z]+)>"
     description = "Promotes a user to a game admin!"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def prepare_args(self, event):
-        self.args["user"] = event["user"]
-        self.args["channel"] = event["channel"]
-
-        rendered_pattern = self.pattern.format(me=self.slack.bot_id)
-        self.args["admin"] = re.match(rendered_pattern, event["text"]).group(1)
+        super().prepare_args(event)
 
     @admin_check
     def execute(self):
+        for i in super().execute():
+            yield i
+
         if self.gamestate.set_admin(self.args["channel"], self.args["admin"]):
-            yield (None, "<@{user}> has promoted <@{admin}> to a game admin :tada:".format(**self.args))
+            yield (None, "<@{admin}> has been promoted to a game admin :tada:".format(**self.args))
         else:
             yield (None, "<@{admin}> is already an admin :face_with_rolling_eyes:".format(**self.args))

--- a/plusplusbot/command/gamestate_commands/set_emojirade_command.py
+++ b/plusplusbot/command/gamestate_commands/set_emojirade_command.py
@@ -19,9 +19,7 @@ class SetEmojirade(GameStateCommand):
                 self.args["channel"] = channel_name
                 break
         else:
-            self.args["channel"] = None
-
-        print(self.args)
+            raise RuntimeError("Unable to find the correct channel for '{0}'".format(self.args["channel"]))
 
     @only_in_progress
     def execute(self):

--- a/plusplusbot/command/general_commands/help_command.py
+++ b/plusplusbot/command/general_commands/help_command.py
@@ -16,13 +16,21 @@ class HelpCommand(Command):
         return pattern
 
     def execute(self):
+        for i in super().execute():
+            yield i
+
         commands = plusplusbot.command.command_registry.CommandRegistry.prepare_commands()
 
         message = "Available commands are:\n```"
         message += "{0:<50}{1}\n".format("Command", "Help")
 
         for command in [c[0] for c in commands.values()]:
-            message += "{0:<50}{1}\n".format(self.format_command(command.pattern), command.description)
+            rendered = self.format_command(command.pattern)
+
+            if len(rendered) > 48:
+                rendered = "{0}...".format(rendered[0:45])
+
+            message += "{0:<50}{1}\n".format(rendered, command.description)
 
         message += "```"
         yield (None, message)

--- a/plusplusbot/command/scorekeeper_commands/history_command.py
+++ b/plusplusbot/command/scorekeeper_commands/history_command.py
@@ -9,6 +9,9 @@ class HistoryCommand(ScoreKeeperCommand):
         super().__init__(*args, **kwargs)
 
     def execute(self):
+        for i in super().execute():
+            yield i
+
         history = self.scorekeeper.history()
 
         if not history:

--- a/plusplusbot/command/scorekeeper_commands/leaderboard_command.py
+++ b/plusplusbot/command/scorekeeper_commands/leaderboard_command.py
@@ -9,6 +9,9 @@ class LeaderboardCommand(ScoreKeeperCommand):
         super().__init__(*args, **kwargs)
 
     def execute(self):
+        for i in super().execute():
+            yield i
+
         leaderboard = self.scorekeeper.leaderboard()
 
         self.logger.debug("Printing leaderboard: {0}".format(leaderboard))

--- a/plusplusbot/command/scorekeeper_commands/minusminus_command.py
+++ b/plusplusbot/command/scorekeeper_commands/minusminus_command.py
@@ -1,23 +1,22 @@
 from plusplusbot.command.scorekeeper_commands.scorekeeper_command import ScoreKeeperCommand
 from plusplusbot.wrappers import admin_check
 
-import re
-
 
 class MinusMinusCommand(ScoreKeeperCommand):
-    pattern = "<@([0-9A-Z]+)> --"
+    pattern = "<@(?P<target_user>[0-9A-Z]+)>[\\s]*--"
     description = "Decrement the users score"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def prepare_args(self, event):
-        self.args["target_user"] = re.match(self.pattern, event["text"]).group(1)
-        self.args["channel"] = event["channel"]
-        self.args["user"] = event["user"]
+        super().prepare_args(event)
 
     @admin_check
     def execute(self):
+        for i in super().execute():
+            yield i
+
         target_user = self.args["target_user"]
 
         self.logger.debug("Decrementing user's score: {0}".format(target_user))

--- a/plusplusbot/command/scorekeeper_commands/scorekeeper_command.py
+++ b/plusplusbot/command/scorekeeper_commands/scorekeeper_command.py
@@ -4,3 +4,10 @@ from plusplusbot.command.commands import Command
 class ScoreKeeperCommand(Command):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    def prepare_args(self, event):
+        super().prepare_args(event)
+
+    def execute(self):
+        for i in super().execute():
+            yield i

--- a/plusplusbot/command/scorekeeper_commands/set_command.py
+++ b/plusplusbot/command/scorekeeper_commands/set_command.py
@@ -1,28 +1,27 @@
 from plusplusbot.command.scorekeeper_commands.scorekeeper_command import ScoreKeeperCommand
 from plusplusbot.wrappers import admin_check
 
-import re
-
 
 class SetCommand(ScoreKeeperCommand):
-    pattern = "<@([0-9A-Z]+)> set (-?[0-9]+)"
+    pattern = "<@(?P<target_user>[0-9A-Z]+)> set (?P<new_score>-?[0-9]+)"
     description = "Manually set the users score"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def prepare_args(self, event):
-        self.args["user"] = event["user"]
-        self.args["channel"] = event["channel"]
+        super().prepare_args(event)
 
-        matches = re.match(self.pattern, event["text"])
-        self.args["target_user"] = matches.group(1)
-        self.args["new_score"] = matches.group(2)
+        self.args["new_score"] = int(self.args["new_score"])
+        print(self.args)
 
     @admin_check
     def execute(self):
+        for i in super().execute():
+            yield i
+
         target_user = self.args["target_user"]
-        new_score = int(self.args["new_score"])
+        new_score = self.args["new_score"]
 
         self.logger.debug("Setting {0} score to: {1}".format(target_user, new_score))
         self.scorekeeper.overwrite(target_user, new_score)

--- a/plusplusbot/gamestate.py
+++ b/plusplusbot/gamestate.py
@@ -138,6 +138,18 @@ class GameState(object):
 
         return True
 
+    def is_admin(self, channel, user):
+        admins = self.state[channel].get("admins", [])
+
+        if not admins:
+            # No admins set yet, so everyone is an admin!
+            return True
+
+        if user in admins:
+            return True
+
+        return False
+
     def new_game(self, channel, old_winner, winner):
         """ Winners should be the unique Slack User IDs """
         self.state[channel]["old_winner"] = old_winner

--- a/plusplusbot/gamestate.py
+++ b/plusplusbot/gamestate.py
@@ -96,20 +96,30 @@ class GameState(object):
         Keeps tabs on the conversation and updates gamestate if required
         Not to be called directly, used as another command source from the bot
         """
-        channel = event["channel"]
-        user = event["user"]
+        channel = str(event["channel"])
+        user = str(event["user"])
+        text = str(event["text"])
         state = self.state[channel]
+
+        # Double check if we're overriding the user
+        user_override_match = Command.user_override_regex.match(event["text"])
+
+        if user_override_match and self.is_admin(channel, user):
+            original_user = user
+            user = user_override_match.groupdict()["user_override"]
+
+            text = text.replace(user_override_match.groupdict()["override_cmd"], "")
 
         # Check to see if the winner is posting emoji's
         if state["step"] == "provided":
             if user == state["winner"]:
-                if ':' in event["text"]:  # ':' means they've posted an emoji :thinking_face:
+                if ':' in text:  # ':' means they've posted an emoji :thinking_face:
                     self.winner_posted(channel)
 
         # Check to see if the users guess is right!
         elif state["step"] == "guessing" and user not in (state["old_winner"], state["winner"]):
             emojirade = state["emojirade"].lower()
-            guess = event["text"].lower()
+            guess = text.lower()
 
             if emojirade in guess:
                 self.logger.debug("emojirade='{0}' guess='{1}' status='correct'".format(emojirade, guess))

--- a/plusplusbot/tests/test_scenarios.py
+++ b/plusplusbot/tests/test_scenarios.py
@@ -6,10 +6,12 @@ class TestBotScenarios(EmojiradeBotTester):
     """
     def test_valid_complete_game(self):
         """ Performs a complete valid round """
-        assert self.state["step"] == "new_game"
-        assert self.state["old_winner"] is None
-        assert self.state["winner"] is None
-        assert self.state["emojirade"] is None
+        assert {
+            "step": "new_game",
+            "old_winner": None,
+            "winner": None,
+            "emojirade": None,
+        }.items() <= self.state.items()
         assert not self.scoreboard
 
         self.send_event(self.events.new_game)

--- a/plusplusbot/tests/test_scenarios.py
+++ b/plusplusbot/tests/test_scenarios.py
@@ -6,12 +6,10 @@ class TestBotScenarios(EmojiradeBotTester):
     """
     def test_valid_complete_game(self):
         """ Performs a complete valid round """
-        assert {
-            "step": "new_game",
-            "old_winner": None,
-            "winner": None,
-            "emojirade": None,
-        }.items() <= self.state.items()
+        assert self.state["step"] == "new_game"
+        assert self.state["old_winner"] == None
+        assert self.state["winner"] == None
+        assert self.state["emojirade"] == None
         assert not self.scoreboard
 
         self.send_event(self.events.new_game)
@@ -97,9 +95,10 @@ class TestBotScenarios(EmojiradeBotTester):
         assert len(self.responses) == 0
 
         self.send_event(self.events.new_game)
-        assert len(self.responses) == 4
+        assert len(self.responses) == 5
 
         responses = [
+            (self.config.channel, "This action was performed by <@{0}>".format(self.config.player_1)),
             (self.config.channel, "<@{0}> has set the old winner to <@{0}> and the winner to <@{1}>".format(self.config.player_1, self.config.player_2)),
             (self.config.channel, "It's now <@{0}>'s turn to provide <@{1}> with the next 'rade!".format(self.config.player_1, self.config.player_2)),
             (self.config.player_1_channel, "You'll now need to send me the new 'rade for <@{0}>".format(self.config.player_2)),
@@ -110,23 +109,25 @@ class TestBotScenarios(EmojiradeBotTester):
             assert response == self.responses[i]
 
         self.send_event(self.events.posted_emojirade)
-        assert len(self.responses) == 6
+        assert len(self.responses) == 8
 
         responses = [
+            (self.config.bot_channel, "This action was performed by <@{0}>".format(self.config.player_1)),
             (self.config.player_2_channel, "Hey, <@{0}> made the 'rade `{1}`, good luck!".format(self.config.player_1, self.config.emojirade)),
             (self.config.channel, ":mailbox: 'rade sent to <@{1}>".format(self.config.player_1, self.config.player_2)),
         ]
 
         for i, response in enumerate(responses):
-            assert response == self.responses[4 + i]
+            assert response == self.responses[5 + i]
 
         self.send_event(self.events.posted_emoji)
-        assert len(self.responses) == 6
+        assert len(self.responses) == 8
 
         self.send_event(self.events.correct_guess)
-        assert len(self.responses) == 10
+        assert len(self.responses) == 13
 
         responses = [
+            (self.config.channel, "This action was performed by <@{0}>".format(self.config.player_3)),
             (self.config.channel, "<@{0}>++".format(self.config.player_3)),
             (self.config.channel, "Congrats <@{0}>, you're now at 1 point".format(self.config.player_3)),
             (self.config.player_2_channel, "You'll now need to send me the new 'rade for <@{0}>".format(self.config.player_3)),
@@ -134,7 +135,7 @@ class TestBotScenarios(EmojiradeBotTester):
         ]
 
         for i, response in enumerate(responses):
-            assert response == self.responses[6 + i]
+            assert response == self.responses[8 + i]
 
     def test_only_guess_when_guessing(self):
         """ Ensures we can only 'guess' correctly when state is guessing """

--- a/plusplusbot/tests/test_scenarios.py
+++ b/plusplusbot/tests/test_scenarios.py
@@ -7,9 +7,9 @@ class TestBotScenarios(EmojiradeBotTester):
     def test_valid_complete_game(self):
         """ Performs a complete valid round """
         assert self.state["step"] == "new_game"
-        assert self.state["old_winner"] == None
-        assert self.state["winner"] == None
-        assert self.state["emojirade"] == None
+        assert self.state["old_winner"] is None
+        assert self.state["winner"] is None
+        assert self.state["emojirade"] is None
         assert not self.scoreboard
 
         self.send_event(self.events.new_game)


### PR DESCRIPTION
This PR adds the following functionality

Base command is updated to silently listen in and react to messages containing 'player=User'

Which if that text exists, extracts the Username, overrides the current contextual 'user' and removes the text from the message.

It also tests an 'original_user' attribute so other downstream processes can look for that to detect if something dodgy is going on.

Tests have been updated/etc.