### PR TITLE
Open a direct message channel if one doesn't exist

### DIFF
--- a/plusplusbot/bot.py
+++ b/plusplusbot/bot.py
@@ -52,6 +52,9 @@ class PlusPlusBot(object):
         if channel.startswith("C"):
             # Plain old channel, just return it
             return channel
+        elif channel.startswith("D"):
+            # Direct message channel, just return it
+            return channel
         elif channel.startswith("U"):
             # Channel is a User ID, which means the real channel is the DM with that user
             dm_id = self.slack.find_im(channel)

--- a/plusplusbot/bot.py
+++ b/plusplusbot/bot.py
@@ -53,8 +53,13 @@ class PlusPlusBot(object):
             # Plain old channel, just return it
             return channel
         elif channel.startswith("U"):
-            # Channel is a User ID, which means the real channel is the IM with that user
-            return self.slack.find_im(channel)
+            # Channel is a User ID, which means the real channel is the DM with that user
+            dm_id = self.slack.find_im(channel)
+
+            if dm_id is None:
+                raise RuntimeError("Unable to find direct message channel for '{0}'".format(channel))
+
+            return dm_id
         else:
             raise NotImplementedError("Returned channel '{0}' wasn't decoded".format(channel))
 
@@ -79,7 +84,7 @@ class PlusPlusBot(object):
                         if channel is not None:
                             channel = self.decode_channel(channel)
                         else:
-                            channel = event["channel"]
+                            channel = self.decode_channel(event["channel"])
 
                         self.slack.sc.rtm_send_message(channel, response)
 

--- a/plusplusbot/slack.py
+++ b/plusplusbot/slack.py
@@ -24,7 +24,14 @@ class SlackClient(object):
     def is_admin(self, user_id):
         return self.user_info(user_id)["is_admin"]
 
-    def find_im(self, userid):
+    def find_im(self, user_id):
+        # Find an existing IM (direct message) ID
+        response = self.sc.api_call("im.open", user=user_id)
+
+        if response["ok"]:
+            return response["channel"]["id"]
+
+        # Attemp to locate an existing IM
         for im in self.sc.api_call("im.list")["ims"]:
             if im["user"] == userid:
                 return im["id"]


### PR DESCRIPTION
If a user has not opened a direct message channel with emojirades bot beforehand, all messages will be ignored.

Get the bot to open a direct message channel on each DM to ensure it's open.

It's also slightly more efficient than listing all DM channels and filtering to the current user.