### PR TITLE
FixWinner command

### DIFF
--- a/plusplusbot/command/command_registry.py
+++ b/plusplusbot/command/command_registry.py
@@ -6,6 +6,7 @@ from plusplusbot.command.gamestate_commands.set_admin_command import SetAdmin
 from plusplusbot.command.gamestate_commands.remove_admin_command import RemoveAdmin
 from plusplusbot.command.gamestate_commands.correct_guess_command import CorrectGuess
 from plusplusbot.command.gamestate_commands.set_emojirade_command import SetEmojirade
+from plusplusbot.command.gamestate_commands.fixwinner_command import FixWinner
 
 from plusplusbot.command.scorekeeper_commands.set_command import SetCommand
 from plusplusbot.command.scorekeeper_commands.history_command import HistoryCommand
@@ -26,6 +27,7 @@ class CommandRegistry:
         SetAdmin,
         SetEmojirade,
         GameStatus,
+        FixWinner,
     ]
 
     @classmethod

--- a/plusplusbot/command/gamestate_commands/fixwinner_command.py
+++ b/plusplusbot/command/gamestate_commands/fixwinner_command.py
@@ -20,12 +20,13 @@ class FixWinner(GameStateCommand):
         loser, winner = self.gamestate.fixwinner(self.args["channel"], self.args["winner"])
 
         if loser is None or winner is None:
-            yield (None, "Failed to fix the winner, please manually fix, sorry :(")
+            yield (None, "Failed to fix the winner, no scores have been updated, please fix manually :(")
             raise StopIteration
 
-        # Mainly for compat with plusplus bot purposes
         yield (None, "<@{0}>--".format(loser))
+        self.scorekeeper.minusminus(loser)
+
         yield (None, "<@{0}>++".format(winner))
-        # TODO: Need to update the actual player scores as well
+        self.scorekeeper.plusplus(winner)
 
         yield (None, "Sorry <@{0}>! <@{1}> has decided to award <@{2}> the win :smiling_imp:".format(loser, self.args["user"], winner))

--- a/plusplusbot/command/gamestate_commands/fixwinner_command.py
+++ b/plusplusbot/command/gamestate_commands/fixwinner_command.py
@@ -1,0 +1,31 @@
+from plusplusbot.command.gamestate_commands.gamestate_command import GameStateCommand
+from plusplusbot.wrappers import admin_or_old_winner_check
+
+
+class FixWinner(GameStateCommand):
+    pattern = "<@{me}> fixwinner <@(?P<winner>[0-9A-Z]+)>"
+    description = "Resets the currently awarded win to another player (in case of a ninja or something)"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def prepare_args(self, event):
+        super().prepare_args(event)
+
+    @admin_or_old_winner_check
+    def execute(self):
+        for i in super().execute():
+            yield i
+
+        loser, winner = self.gamestate.fixwinner(self.args["channel"], self.args["winner"])
+
+        if loser is None or winner is None:
+            yield (None, "Failed to fix the winner, please manually fix, sorry :(")
+            raise StopIteration
+
+        # Mainly for compat with plusplus bot purposes
+        yield (None, "<@{0}>--".format(loser))
+        yield (None, "<@{0}>++".format(winner))
+        # TODO: Need to update the actual player scores as well
+
+        yield (None, "Sorry <@{0}>! <@{1}> has decided to award <@{2}> the win :smiling_imp:".format(loser, self.args["user"], winner))

--- a/plusplusbot/command/gamestate_commands/inferred_correct_guess_command.py
+++ b/plusplusbot/command/gamestate_commands/inferred_correct_guess_command.py
@@ -1,10 +1,20 @@
 from plusplusbot.command.gamestate_commands.gamestate_command import GameStateCommand
 from plusplusbot.wrappers import only_actively_guessing
 
+import random
+
 
 class InferredCorrectGuess(GameStateCommand):
     pattern = None
     description = "Takes the user that send the event as the winner, this is only ever fired internally"
+    first_emojis = [
+        ":tada:",
+        ":first_place_medal:",
+        ":sunglasses:",
+        ":nerd_face:",
+        ":birthday:",
+        ":beers:",
+    ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/plusplusbot/gamestate.py
+++ b/plusplusbot/gamestate.py
@@ -200,5 +200,13 @@ class GameState(object):
         """ Returns the game state """
         return self.state[channel]
 
+    def fixwinner(self, channel, winner):
+        """ Updates the current winner with the newly provided winner and handles score updates """
+        loser = self.state[channel]["winner"]
+        self.state[channel]["winner"] = winner
+        self.save()
+
+        return loser, winner
+
     def save(self):
         self.config.save(self.state)

--- a/plusplusbot/scorekeeper.py
+++ b/plusplusbot/scorekeeper.py
@@ -60,7 +60,7 @@ class ScoreKeeper(object):
                 self.logger.info("Loaded scores from {0}".format(filename))
 
     def current_score(self, user):
-        leader = sorted(self.scoreboard.items(), key=lambda x: x[1], reverse=True)[0]
+        leader, score = sorted(self.scoreboard.items(), key=lambda x: x[1], reverse=True)[0]
         return self.scoreboard[user], user == leader
 
     def plusplus(self, user):

--- a/plusplusbot/tests/helper.py
+++ b/plusplusbot/tests/helper.py
@@ -8,6 +8,7 @@ import os
 
 logging.basicConfig(level=logging.DEBUG)
 
+
 class EmojiradeBotTester(unittest.TestCase):
     """
     Base testing class that creates a bot that will accept events to test against

--- a/plusplusbot/tests/helper.py
+++ b/plusplusbot/tests/helper.py
@@ -85,6 +85,8 @@ class EmojiradeBotTester(unittest.TestCase):
         player_2_channel = "D00000002"
         player_3 = "U00000003"
         player_3_channel = "D00000003"
+        player_4 = "U00000004"
+        player_4_channel = "D00000004"
         emojirade = "testing"
 
         event_config = {
@@ -98,6 +100,8 @@ class EmojiradeBotTester(unittest.TestCase):
             "player_2_channel": player_2_channel,
             "player_3": player_3,
             "player_3_channel": player_3_channel,
+            "player_4": player_4,
+            "player_4_channel": player_4_channel,
             "emojirade": emojirade,
         }
 
@@ -166,6 +170,13 @@ class EmojiradeBotTester(unittest.TestCase):
                 **{
                     "user": player_1,
                     "text": "<@{0}> leaderboard".format(bot_id),
+                },
+            },
+            "fixwinner": {
+                **base_event,
+                **{
+                    "user": player_2,
+                    "text": "<@{0}> fixwinner <@{1}>".format(bot_id, player_4),
                 },
             },
         }

--- a/plusplusbot/tests/test_commands.py
+++ b/plusplusbot/tests/test_commands.py
@@ -1,5 +1,6 @@
 from plusplusbot.tests.helper import EmojiradeBotTester
 
+
 class TestBotCommands(EmojiradeBotTester):
     """
     Tests various game commands against the bot

--- a/plusplusbot/tests/test_commands.py
+++ b/plusplusbot/tests/test_commands.py
@@ -21,3 +21,22 @@ class TestBotCommands(EmojiradeBotTester):
         self.send_event(self.events.leaderboard)
 
         assert (self.config.channel, "1. U00000003 [1 point]") in self.responses
+
+    def test_fixwinner(self):
+        """ Ensure fixwinner does the right thing """
+        self.reset_and_transition_to("guessing")
+
+        state = self.bot.gamestate.state[self.config.channel]
+
+        self.send_event(self.events.correct_guess)
+        assert state["old_winner"] == self.config.player_2
+        assert state["winner"] == self.config.player_3
+        print(self.bot.scorekeeper.leaderboard())
+        assert self.bot.scorekeeper.current_score(self.config.player_3) == (1, True)
+        assert self.bot.scorekeeper.current_score(self.config.player_4) == (0, False)
+
+        self.send_event(self.events.fixwinner)
+        assert state["old_winner"] == self.config.player_2
+        assert state["winner"] == self.config.player_4
+        assert self.bot.scorekeeper.current_score(self.config.player_3) == (0, False)
+        assert self.bot.scorekeeper.current_score(self.config.player_4) == (1, True)

--- a/plusplusbot/tests/test_scenarios.py
+++ b/plusplusbot/tests/test_scenarios.py
@@ -1,5 +1,6 @@
 from plusplusbot.tests.helper import EmojiradeBotTester
 
+
 class TestBotScenarios(EmojiradeBotTester):
     """
     Tests various game scenarios against the bot
@@ -181,8 +182,8 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["emojirade"] is None
         assert (self.config.channel, "<@{0}>++".format(self.config.player_3)) in self.responses
         assert any(
-            self.config.channel == channel and
-            "Congrats <@{0}>, you're now at 1 point".format(self.config.player_3) in msg
+            self.config.channel == channel
+            and "Congrats <@{0}>, you're now at 1 point".format(self.config.player_3) in msg
             for channel, msg in self.responses
         )
 
@@ -209,7 +210,7 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["emojirade"] is None
         assert (self.config.channel, "<@{0}>++".format(self.config.player_1)) in self.responses
         assert any(
-            self.config.channel == channel and
-            "Congrats <@{0}>, you're now at 1 point".format(self.config.player_1) in msg
+            self.config.channel == channel
+            and "Congrats <@{0}>, you're now at 1 point".format(self.config.player_1) in msg
             for channel, msg in self.responses
         )

--- a/plusplusbot/tests/test_scenarios.py
+++ b/plusplusbot/tests/test_scenarios.py
@@ -104,8 +104,9 @@ class TestBotScenarios(EmojiradeBotTester):
             (self.config.player_1_channel, "Please reply back in the format `emojirade Point Break` if `Point Break` was the new 'rade"),
         ]
 
-        for i, response in enumerate(responses):
-            assert response == self.responses[i]
+        for i, (channel, msg) in enumerate(responses):
+            assert channel == self.responses[i][0]
+            assert msg in self.responses[i][1]
 
         self.send_event(self.events.posted_emojirade)
         assert len(self.responses) == 6
@@ -115,8 +116,9 @@ class TestBotScenarios(EmojiradeBotTester):
             (self.config.channel, ":mailbox: 'rade sent to <@{1}>".format(self.config.player_1, self.config.player_2)),
         ]
 
-        for i, response in enumerate(responses):
-            assert response == self.responses[4 + i]
+        for i, (channel, msg) in enumerate(responses):
+            assert channel == self.responses[4 + i][0]
+            assert msg in self.responses[4 + i][1]
 
         self.send_event(self.events.posted_emoji)
         assert len(self.responses) == 6
@@ -131,8 +133,9 @@ class TestBotScenarios(EmojiradeBotTester):
             (self.config.player_2_channel, "Please reply back in the format `emojirade Point Break` if `Point Break` was the new 'rade"),
         ]
 
-        for i, response in enumerate(responses):
-            assert response == self.responses[6 + i]
+        for i, (channel, msg) in enumerate(responses):
+            assert channel == self.responses[6 + i][0]
+            assert msg in self.responses[6 + i][1]
 
     def test_only_guess_when_guessing(self):
         """ Ensures we can only 'guess' correctly when state is guessing """
@@ -177,7 +180,7 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["winner"] == self.config.player_3
         assert self.state["emojirade"] is None
         assert (self.config.channel, "<@{0}>++".format(self.config.player_3)) in self.responses
-        assert (self.config.channel, "Congrats <@{0}>, you're now at 1 point".format(self.config.player_3)) in self.responses
+        assert any(self.config.channel == channel and "Congrats <@{0}>, you're now at 1 point".format(self.config.player_3) in msg for channel, msg in self.responses)
 
         emojirade = "second"
         override = {"user": self.config.player_2, "text": "emojirade {0}".format(emojirade)}

--- a/plusplusbot/tests/test_scenarios.py
+++ b/plusplusbot/tests/test_scenarios.py
@@ -180,7 +180,11 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["winner"] == self.config.player_3
         assert self.state["emojirade"] is None
         assert (self.config.channel, "<@{0}>++".format(self.config.player_3)) in self.responses
-        assert any(self.config.channel == channel and "Congrats <@{0}>, you're now at 1 point".format(self.config.player_3) in msg for channel, msg in self.responses)
+        assert any(
+            self.config.channel == channel and
+            "Congrats <@{0}>, you're now at 1 point".format(self.config.player_3) in msg
+            for channel, msg in self.responses
+        )
 
         emojirade = "second"
         override = {"user": self.config.player_2, "text": "emojirade {0}".format(emojirade)}
@@ -204,4 +208,8 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["winner"] == self.config.player_1
         assert self.state["emojirade"] is None
         assert (self.config.channel, "<@{0}>++".format(self.config.player_1)) in self.responses
-        assert (self.config.channel, "Congrats <@{0}>, you're now at 1 point".format(self.config.player_1)) in self.responses
+        assert any(
+            self.config.channel == channel and
+            "Congrats <@{0}>, you're now at 1 point".format(self.config.player_1) in msg
+            for channel, msg in self.responses
+        )

--- a/plusplusbot/wrappers.py
+++ b/plusplusbot/wrappers.py
@@ -1,6 +1,6 @@
-
 # Convenience wrappers used to assert game state or permissions checks
 # These are used directly by a commands execute function
+
 
 def admin_check(command):
     def wrapped_command(self):
@@ -17,6 +17,7 @@ def admin_check(command):
             yield channel, response
 
     return wrapped_command
+
 
 def admin_or_old_winner_check(command):
     def wrapped_command(self):
@@ -43,6 +44,7 @@ def admin_or_old_winner_check(command):
 
     return wrapped_command
 
+
 def only_in_progress(command):
     def wrapped_command(self):
         channel = self.args["channel"]
@@ -55,6 +57,7 @@ def only_in_progress(command):
             yield channel, response
 
     return wrapped_command
+
 
 def only_actively_guessing(command):
     def wrapped_command(self):

--- a/plusplusbot/wrappers.py
+++ b/plusplusbot/wrappers.py
@@ -18,6 +18,31 @@ def admin_check(command):
 
     return wrapped_command
 
+def admin_or_old_winner_check(command):
+    def wrapped_command(self):
+        channel = self.args["channel"]
+
+        is_old_winner = False
+        is_admin = False
+
+        if self.args["user"] == self.gamestate.state[channel]["old_winner"]:
+            is_old_winner = True
+
+        if self.gamestate.state[channel]["admins"] and self.args["user"] in self.gamestate.state[channel]["admins"]:
+            is_admin = True
+
+        if not is_old_winner and not is_admin:
+            yield (None, "Sorry <@{user}> but you need to be the old winner (or a game admin) to do that :upside_down_face:".format(**self.args))
+
+            admins = ["<@{0}>".format(admin) for admin in self.gamestate.state[channel]["admins"]]
+            yield (None, "Game admins currently are: {0}".format(", ".join(admins)))
+            raise StopIteration
+
+        for channel, response in command(self):
+            yield channel, response
+
+    return wrapped_command
+
 def only_in_progress(command):
     def wrapped_command(self):
         channel = self.args["channel"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,4 @@
 universal=0
 
 [pycodestyle]
-ignore=E302,E305
 max-line-length = 160


### PR DESCRIPTION
This command allows the user to 'rewrite' the previous winner to a new winner.

Useful for when there's an incorrect ninja or something!

Fixes #46 