### PR TITLE
Fix Scott breaking emojirades

### DIFF
--- a/plusplusbot/command/gamestate_commands/set_emojirade_command.py
+++ b/plusplusbot/command/gamestate_commands/set_emojirade_command.py
@@ -1,5 +1,6 @@
 from plusplusbot.command.gamestate_commands.gamestate_command import GameStateCommand
 from plusplusbot.wrappers import only_in_progress
+from plusplusbot.helpers import sanitize_emojirade
 from plusplusbot.checks import emojirade_is_banned
 
 
@@ -39,8 +40,8 @@ class SetEmojirade(GameStateCommand):
             yield (None, "Sorry, but that emojirade contained a banned word/phrase :no_good:, try again?")
             raise StopIteration
 
-        # Break the alternatives out and strip whitespace (from front/end of each 'rade)
-        emojirades = [i.strip() for i in self.args["emojirade"].split("|")]
+        # Break the alternatives out and sanitize the emojirade (apply consistent sanitization)
+        emojirades = [sanitize_emojirade(i) for i in self.args["emojirade"].split("|")]
 
         self.gamestate.set_emojirade(self.args["channel"], emojirades)
 

--- a/plusplusbot/gamestate.py
+++ b/plusplusbot/gamestate.py
@@ -120,15 +120,26 @@ class GameState(object):
         # Check to see if the users guess is right!
         elif state["step"] == "guessing" and user not in (state["old_winner"], state["winner"]):
             def sanitize(text):
+                # Remove any random misc chars we deem unnessesary
                 stripped = re.sub("['\"-_+=]", "", text)
+
+                # unidecode will normalize to ASCII
                 normalized = unidecode(stripped)
+
                 return normalized
 
             emojirades = [sanitize(i.lower()) for i in state["emojirade"]]
             guess = sanitize(text.lower())
+            guess_len = len(guess)
 
             for emojirade in emojirades:
-                if emojirade in guess:
+                if guess_len > (len(emojirade) * 0.10):
+                    # Skip as it's too big?
+                    continue
+
+                to_search = r"\b{0}\b".format(emojirade)
+
+                if re.search(to_search, guess):
                     self.logger.debug("emojirade='{0}' guess='{1}' status='correct'".format(emojirade, guess))
 
                     yield InferredCorrectGuess

--- a/plusplusbot/gamestate.py
+++ b/plusplusbot/gamestate.py
@@ -3,6 +3,7 @@ import json
 import re
 
 from collections import defaultdict
+from unidecode import unidecode
 
 from plusplusbot.command.gamestate_commands.inferred_correct_guess_command import InferredCorrectGuess
 from plusplusbot.handlers import get_configuration_handler
@@ -119,7 +120,9 @@ class GameState(object):
         # Check to see if the users guess is right!
         elif state["step"] == "guessing" and user not in (state["old_winner"], state["winner"]):
             def sanitize(text):
-                return re.sub("['\"-_+=]", "", text)
+                stripped = re.sub("['\"-_+=]", "", text)
+                normalized = unidecode(stripped)
+                return normalized
 
             emojirades = [sanitize(i.lower()) for i in state["emojirade"]]
             guess = sanitize(text.lower())

--- a/plusplusbot/helpers.py
+++ b/plusplusbot/helpers.py
@@ -1,0 +1,36 @@
+import re
+
+from unidecode import unidecode
+
+
+class ScottFactorExceededException(Exception):
+    pass
+
+
+def sanitize_emojirade(text):
+    # Lowercase the text
+    lowered = text.lower()
+
+    # Strip whitespace
+    stripped = lowered.strip()
+
+    # Remove any random misc chars we deem unnessesary
+    scrubbed = re.sub("['\"-_+=]", "", stripped)
+
+    # unidecode will normalize to ASCII
+    normalized = unidecode(scrubbed)
+
+    return normalized
+
+
+def match_emojirade(guess, emojirades, scott_factor=2):
+    guess = re.escape(guess)
+
+    for emojirade in emojirades:
+        if not (len(emojirade) / scott_factor) < len(guess) < (len(emojirade) * scott_factor):
+            raise ScottFactorExceededException("Guess exceeded the Scott Factor")
+
+        if re.search(re.escape(emojirade), guess):
+            return True
+
+    return False

--- a/plusplusbot/helpers.py
+++ b/plusplusbot/helpers.py
@@ -30,7 +30,7 @@ def match_emojirade(guess, emojirades, scott_factor=2):
         if not (len(emojirade) / scott_factor) < len(guess) < (len(emojirade) * scott_factor):
             raise ScottFactorExceededException("Guess exceeded the Scott Factor")
 
-        if re.search(re.escape(emojirade), guess):
+        if re.search(r"\b{0}\b".format(re.escape(emojirade)), guess):
             return True
 
     return False

--- a/plusplusbot/helpers.py
+++ b/plusplusbot/helpers.py
@@ -27,7 +27,7 @@ def match_emojirade(guess, emojirades, scott_factor=2):
     guess = re.escape(guess)
 
     for emojirade in emojirades:
-        if not (len(emojirade) / scott_factor) < len(guess) < (len(emojirade) * scott_factor):
+        if len(guess) > (len(emojirade) * scott_factor):
             raise ScottFactorExceededException("Guess exceeded the Scott Factor")
 
         if re.search(r"\b{0}\b".format(re.escape(emojirade)), guess):

--- a/plusplusbot/tests/test_scenarios.py
+++ b/plusplusbot/tests/test_scenarios.py
@@ -289,3 +289,43 @@ class TestBotScenarios(EmojiradeBotTester):
         self.send_event({**self.events.correct_guess, **override})
         assert self.state["step"] == "waiting"
         assert self.state["emojirade"] is None
+
+    def test_scott_factor_exceeded(self):
+        """ Performs tests for guesses exceeding the scott factor """
+        # Test something 'within' the scott factor
+        self.reset_and_transition_to("guessing")
+
+        assert self.state["step"] == "guessing"
+
+        override = {"text": "0 {0} 1".format(self.config.emojirade)}
+        self.send_event({**self.events.correct_guess, **override})
+        assert self.state["step"] == "waiting"
+
+        # Test something 'outside' the scott factor
+        self.reset_and_transition_to("guessing")
+
+        assert self.state["step"] == "guessing"
+
+        override = {"text": "blah1234567890 {0} blah0987654321".format(self.config.emojirade)}
+        self.send_event({**self.events.correct_guess, **override})
+        assert self.state["step"] == "guessing"
+
+    def test_word_boundary_matching(self):
+        """ Performs tests to ensure emojirade matches only occur on word boundaries """
+        # Test a word, should work
+        self.reset_and_transition_to("guessing")
+
+        assert self.state["step"] == "guessing"
+
+        override = {"text": "0 {0} 1".format(self.events.correct_guess["text"])}
+        self.send_event({**self.events.correct_guess, **override})
+        assert self.state["step"] == "waiting"
+
+        # Test a sub-word, shouldn't work
+        self.reset_and_transition_to("guessing")
+
+        assert self.state["step"] == "guessing"
+
+        override = {"text": "0 a{0}b 1".format(self.events.correct_guess["text"])}
+        self.send_event({**self.events.correct_guess, **override})
+        assert self.state["step"] == "guessing"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 slackclient>=1.1,<2
 boto3>=1.5,<2
+Unidecode>=1,<2

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
     packages=find_packages(),
     install_requires=[
         "slackclient>=1.1,<2",
-        "boto3>=1.5,<2"
+        "boto3>=1.5,<2",
+        "Unidecode>=1,<2"
     ],
     python_requires="~=3.5",
     extras_require={


### PR DESCRIPTION
Fixes #69 

This PR refactors the emojirade sanitization and matching logic into a single place.

Sanitization logic is:
1. Lowercase the emojirade/guess
2. Strip all leading/ending whitespace
3. Scrub meta characters that don't need to be in there
4. Normalize to ASCII to remove any weird chars

Anti-Scott features include checking to see if the guess is within a 'scott factor' of the emojirade.