### PR TITLE
Use the 'raw' emojirade for 'rade communication

### DIFF
--- a/plusplusbot/command/gamestate_commands/set_emojirade_command.py
+++ b/plusplusbot/command/gamestate_commands/set_emojirade_command.py
@@ -43,7 +43,7 @@ class SetEmojirade(GameStateCommand):
             return
 
         # Break the alternatives out and sanitize the emojirade (apply consistent sanitization)
-        raw_emojirades = [i for i in self.args["emojirade"].split("|")]
+        raw_emojirades = [i.strip() for i in self.args["emojirade"].split("|")]
         sanitized_emojirades = [sanitize_emojirade(i) for i in raw_emojirades]
 
         self.gamestate.set_emojirade(self.args["channel"], sanitized_emojirades)

--- a/plusplusbot/command/gamestate_commands/set_emojirade_command.py
+++ b/plusplusbot/command/gamestate_commands/set_emojirade_command.py
@@ -43,22 +43,28 @@ class SetEmojirade(GameStateCommand):
             return
 
         # Break the alternatives out and sanitize the emojirade (apply consistent sanitization)
-        emojirades = [sanitize_emojirade(i) for i in self.args["emojirade"].split("|")]
+        raw_emojirades = [i for i in self.args["emojirade"].split("|")]
+        sanitized_emojirades = [sanitize_emojirade(i) for i in raw_emojirades]
 
-        self.gamestate.set_emojirade(self.args["channel"], emojirades)
+        self.gamestate.set_emojirade(self.args["channel"], sanitized_emojirades)
 
         winner = self.gamestate.state[self.args["channel"]]["winner"]
 
-        # Let the user know their 'rade has been accepted
-        yield (self.args["user"], "Thanks for that! I've let <@{winner}> know!".format(winner=winner))
-
-        # DM the winner with the new rade
-        if len(emojirades) > 1:
-            alternatives = ", with alternatives " + " OR ".join(["`{0}`".format(i) for i in emojirades[1:]])
+        # DM the winner with the new emojirade
+        if len(raw_emojirades) > 1:
+            alternatives = ", with alternatives " + " OR ".join(["`{0}`".format(i) for i in raw_emojirades[1:]])
         else:
             alternatives = ""
 
-        yield (winner, "Hey, <@{user}> made the 'rade `{first}`{alternatives}, good luck!".format(**self.args, first=emojirades[0], alternatives=alternatives))
+        msg = "Hey, <@{user}> made the 'rade `{first}`{alternatives}, good luck!".format(
+            **self.args,
+            first=raw_emojirades[0],
+            alternatives=alternatives
+        )
+        yield (winner, msg)
+
+        # Let the user know their 'rade has been accepted
+        yield (self.args["user"], "Thanks for that! I've let <@{winner}> know!".format(winner=winner))
 
         # Let everyone else know
         yield (self.args["channel"], ":mailbox: 'rade sent to <@{winner}>".format(winner=winner))

--- a/plusplusbot/tests/test_commands.py
+++ b/plusplusbot/tests/test_commands.py
@@ -88,6 +88,36 @@ class TestBotCommands(EmojiradeBotTester):
         self.send_event(self.events.posted_emojirade)
         assert state["step"] == "provided"
 
+    def test_set_emojirade_raw_output(self):
+        """ Ensure that the emojirade passed to the winner isn't sanitized """
+        self.reset_and_transition_to("waiting")
+
+        emojirade = "test-123-test_123"
+
+        override = {"text": "emojirade {0}".format(emojirade)}
+        self.send_event({**self.events.posted_emojirade, **override})
+
+        assert (self.config.player_2_channel,
+                "Hey, <@{old_winner}> made the 'rade `{emojirade}`, good luck!".format(
+                    old_winner=self.config.player_1,
+                    emojirade=emojirade
+                )) in self.responses
+
+    def test_set_emojirade_alternatives_output(self):
+        """ Ensure that the emojirade alternatives output is expected """
+        self.reset_and_transition_to("waiting")
+
+        emojirade = "foo | bar"
+
+        override = {"text": "emojirade {0}".format(emojirade)}
+        self.send_event({**self.events.posted_emojirade, **override})
+
+        assert (self.config.player_2_channel,
+                "Hey, <@{old_winner}> made the 'rade `foo`, with alternatives `bar`, good luck!".format(
+                    old_winner=self.config.player_1,
+                    emojirade=emojirade
+                )) in self.responses
+
     def test_user_override(self):
         self.reset_and_transition_to("guessing")
 

--- a/plusplusbot/tests/test_scenarios.py
+++ b/plusplusbot/tests/test_scenarios.py
@@ -132,10 +132,10 @@ class TestBotScenarios(EmojiradeBotTester):
 
         # Expected *new* responses
         responses = [
-            response(self.config.player_1_channel,
-                     "Thanks for that! I've let <@{0}> know!".format(self.config.player_2)),
             response(self.config.player_2_channel,
                      "Hey, <@{0}> made the 'rade `{1}`, good luck!".format(self.config.player_1, self.config.emojirade)),
+            response(self.config.player_1_channel,
+                     "Thanks for that! I've let <@{0}> know!".format(self.config.player_2)),
             response(self.config.channel,
                      ":mailbox: 'rade sent to <@{1}>".format(self.config.player_1, self.config.player_2)),
         ]


### PR DESCRIPTION
Keep the 'sanitized' version just for internal usage only.

Closes #80 