### PR TITLE
Command channel context

### DIFF
--- a/plusplusbot/command/gamestate_commands/set_emojirade_command.py
+++ b/plusplusbot/command/gamestate_commands/set_emojirade_command.py
@@ -1,5 +1,5 @@
 from plusplusbot.command.gamestate_commands.gamestate_command import GameStateCommand
-from plusplusbot.wrappers import only_in_progress
+from plusplusbot.wrappers import only_in_progress, only_as_direct_message
 from plusplusbot.helpers import sanitize_text
 from plusplusbot.checks import emojirade_is_banned
 
@@ -19,8 +19,12 @@ class SetEmojirade(GameStateCommand):
     def prepare_args(self, event):
         super().prepare_args(event)
 
+        # No matter what the final channel is, save the original one
+        # This will override the 'original_channel' from an admin override
+        # /shrug
+        self.args["original_channel"] = self.args["channel"]
+
         # Figure out the channel to use
-        # TODO: Decide if we should be getting the user to explicitly specify the channel?
         for channel_name, channel in self.gamestate.state.items():
             if channel["step"] == "waiting":
                 self.args["channel"] = channel_name
@@ -28,6 +32,7 @@ class SetEmojirade(GameStateCommand):
         else:
             self.args["channel"] = None
 
+    @only_as_direct_message
     @only_in_progress
     def execute(self):
         yield from super().execute()

--- a/plusplusbot/tests/test_commands.py
+++ b/plusplusbot/tests/test_commands.py
@@ -163,6 +163,18 @@ class TestBotCommands(EmojiradeBotTester):
                     emojirade=emojirade
                 )) in self.responses
 
+    def test_set_emojirade_public_channel(self):
+        """ Ensure that the emojirade can only be set in a DM channel """
+        self.reset_and_transition_to("waiting")
+
+        override = {"channel": self.config.channel}
+        self.send_event({**self.events.posted_emojirade, **override})
+
+        print(self.responses)
+        assert (self.config.player_1_channel,
+                "Sorry, but this command can only be sent as a direct message!"
+                ) in self.responses
+
     def test_user_override(self):
         self.reset_and_transition_to("guessing")
 

--- a/plusplusbot/wrappers.py
+++ b/plusplusbot/wrappers.py
@@ -80,3 +80,16 @@ def only_guessing(command):
         yield from command(self)
 
     return wrapped_command
+
+
+def only_as_direct_message(command):
+    def wrapped_command(self):
+        channel = self.args["channel"]
+
+        if not channel.startswith("D"):
+            yield (None, "Sorry, but this command can only be sent as a direct message!")
+            return
+
+        yield from command(self)
+
+    return wrapped_command

--- a/plusplusbot/wrappers.py
+++ b/plusplusbot/wrappers.py
@@ -84,10 +84,12 @@ def only_guessing(command):
 
 def only_as_direct_message(command):
     def wrapped_command(self):
-        channel = self.args["channel"]
+        # We need to check the 'original_channel'
+        # As the 'channel' is overridden by prepare_args
+        channel = self.args["original_channel"]
 
         if not channel.startswith("D"):
-            yield (None, "Sorry, but this command can only be sent as a direct message!")
+            yield (self.args["user"], "Sorry, but this command can only be sent as a direct message!")
             return
 
         yield from command(self)


### PR DESCRIPTION
This PR adds the ability to filter incoming messages by channel, specifically a DM, but can be expanded to be any type of channel.

Closes #103 