### PR TITLE
Remove duplicate whitespace during sanitization

### DIFF
--- a/plusplusbot/helpers.py
+++ b/plusplusbot/helpers.py
@@ -20,8 +20,8 @@ def sanitize_text(text):
     # Lowercase the text
     lowered = normalized.lower()
 
-    # Strip whitespace
-    stripped = lowered.strip()
+    # Strip excess whitespace
+    stripped = ' '.join(lowered.split())
 
     # Remove any random misc chars we deem unnessesary
     scrubbed = stripped.translate(remove_punctuation)

--- a/plusplusbot/helpers.py
+++ b/plusplusbot/helpers.py
@@ -20,13 +20,13 @@ def sanitize_text(text):
     # Lowercase the text
     lowered = normalized.lower()
 
-    # Strip excess whitespace
-    stripped = ' '.join(lowered.split())
-
     # Remove any random misc chars we deem unnessesary
-    scrubbed = stripped.translate(remove_punctuation)
+    scrubbed = lowered.translate(remove_punctuation)
 
-    return scrubbed
+    # Strip excess whitespace
+    stripped = ' '.join(scrubbed.split())
+
+    return stripped
 
 
 def match_emojirade(guess, emojirades, scott_factor=2):

--- a/plusplusbot/tests/test_scenarios.py
+++ b/plusplusbot/tests/test_scenarios.py
@@ -331,6 +331,15 @@ class TestBotScenarios(EmojiradeBotTester):
         self.send_event({**self.events.correct_guess, **override})
         assert self.state["step"] == "guessing"
 
+    def test_sanitization(self):
+        """ Test that the sanitize_text helper works as expected """
+        self.reset_and_transition_to("waiting")
+
+        override = {"text": u'emojirade   Späce : THE\t\t\tfinal\v- f_r_ö_n+t/ier'}
+        self.send_event({**self.events.posted_emojirade, **override})
+        assert self.state["step"] == "provided"
+        assert self.state["emojirade"] == ["space the final frontier"]
+
     def test_emoji_detection(self):
         """ Performs tests to ensure when an emoji is posted the game progresses in state """
         self.reset_and_transition_to("provided")


### PR DESCRIPTION
Replace strip() with a split() and join() which will remove both leading/trailing whitespace and any internal duplicates.