### PR TITLE
Show raw 'rade on a correct guess

### DIFF
--- a/plusplusbot/commands/gamestate_commands/correct_guess_command.py
+++ b/plusplusbot/commands/gamestate_commands/correct_guess_command.py
@@ -48,8 +48,13 @@ class CorrectGuessCommand(BaseCommand):
             return
 
         # Save a copy of the emojirade, as below clears it
-        raw_emojirades = list(state["emojirade"])
-        first_emojirade = raw_emojirades[0]
+        raw_emojirades = [i.replace("`", "") for i in state["emojirade"]]
+        first_emojirade = raw_emojirades.pop(0)
+
+        if raw_emojirades:
+            alternatives = ", with alternatives " + " OR ".join([f"`{i}`" for i in raw_emojirades[1:]])
+        else:
+            alternatives = ""
 
         self.gamestate.correct_guess(self.args["channel"], self.args["target_user"])
         score, position = self.scorekeeper.plusplus(self.args["channel"], self.args["target_user"])
@@ -65,10 +70,8 @@ class CorrectGuessCommand(BaseCommand):
 
         emoji = f" {emoji}"
 
-        if len(raw_emojirades) > 1:
-            alternatives = ", with alternatives " + " OR ".join([f"`{i}`" for i in raw_emojirades[1:]])
-        else:
-            alternatives = ""
+        if state.get("first_guess", False):
+            yield(None, "Holy bejesus Batman :bat::man:, they guessed it in one go! :clap:")
 
         yield (None, f"Congrats <@{state['winner']}>, you're now at {score} point{'s' if score > 1 else ''}{emoji}")
         yield (None, f"The correct emojirade was `{first_emojirade}`{alternatives}")

--- a/plusplusbot/commands/gamestate_commands/inferred_correct_guess_command.py
+++ b/plusplusbot/commands/gamestate_commands/inferred_correct_guess_command.py
@@ -39,8 +39,13 @@ class InferredCorrectGuessCommand(BaseCommand):
         state = self.gamestate.state[self.args["channel"]]
 
         # Save a copy of the emojirade, as below clears it
-        raw_emojirades = list(state["emojirade"])
-        first_emojirade = raw_emojirades[0]
+        raw_emojirades = [i.replace("`", "") for i in state["raw_emojirade"]]
+        first_emojirade = raw_emojirades.pop(0)
+
+        if raw_emojirades:
+            alternatives = ", with alternatives " + " OR ".join([f"`{i}`" for i in raw_emojirades[1:]])
+        else:
+            alternatives = ""
 
         self.gamestate.correct_guess(self.args["channel"], self.args["target_user"])
         score, position = self.scorekeeper.plusplus(self.args["channel"], self.args["target_user"])
@@ -55,11 +60,6 @@ class InferredCorrectGuessCommand(BaseCommand):
             emoji = random.choice(self.other_emojis)
 
         emoji = f" {emoji}"
-
-        if len(raw_emojirades) > 1:
-            alternatives = ", with alternatives " + " OR ".join([f"`{i}`" for i in raw_emojirades[1:]])
-        else:
-            alternatives = ""
 
         if state.get("first_guess", False):
             yield(None, "Holy bejesus Batman :bat::man:, they guessed it in one go! :clap:")

--- a/plusplusbot/commands/gamestate_commands/set_emojirade_command.py
+++ b/plusplusbot/commands/gamestate_commands/set_emojirade_command.py
@@ -1,6 +1,5 @@
 from plusplusbot.wrappers import only_in_progress, only_as_direct_message
 from plusplusbot.checks import emojirade_is_banned
-from plusplusbot.helpers import sanitize_text
 from plusplusbot.commands import BaseCommand
 
 
@@ -52,11 +51,10 @@ class SetEmojiradeCommand(BaseCommand):
             yield (None, "Sorry, but that emojirade contained a banned word/phrase :no_good:, try again?")
             return
 
-        # Break the alternatives out and sanitize the emojirade (apply consistent sanitization)
+        # Break the alternatives out
         raw_emojirades = [i.strip() for i in self.args["emojirade"].split("|")]
-        sanitized_emojirades = [sanitize_text(i) for i in raw_emojirades]
 
-        self.gamestate.set_emojirade(self.args["channel"], sanitized_emojirades)
+        self.gamestate.set_emojirade(self.args["channel"], raw_emojirades)
 
         winner = self.gamestate.state[self.args["channel"]]["winner"]
 

--- a/plusplusbot/gamestate.py
+++ b/plusplusbot/gamestate.py
@@ -8,6 +8,7 @@ from plusplusbot.commands.gamestate_commands.inferred_correct_guess_command impo
 from plusplusbot.helpers import sanitize_text, match_emojirade, match_emoji
 from plusplusbot.helpers import ScottFactorExceededException
 from plusplusbot.handlers import get_configuration_handler
+
 from plusplusbot.commands import BaseCommand
 
 
@@ -80,6 +81,7 @@ class GameState(object):
                 "old_winner": None,
                 "winner": None,
                 "emojirade": None,
+                "raw_emojirade": None,
                 "admins": [],
             }
 
@@ -192,14 +194,17 @@ class GameState(object):
         self.state[channel]["winner"] = winner
         self.state[channel]["step"] = "waiting"
         self.state[channel]["emojirade"] = None
+        self.state[channel]["raw_emojirade"] = None
         self.save()
 
-    def set_emojirade(self, channel, emojirade):
+    def set_emojirade(self, channel, emojirades):
         """ New emojirade word(s), 'emojirade' is a list of accepted answers """
         if self.state[channel]["step"] != "waiting":
             raise self.InvalidStateException("Expecting {channel}'s state to be 'waiting', it is actually {self.state[channel]['step'])}")
 
-        self.state[channel]["emojirade"] = emojirade
+        self.state[channel]["emojirade"] = [sanitize_text(i) for i in emojirades]
+        self.state[channel]["raw_emojirade"] = emojirades
+
         self.state[channel]["step"] = "provided"
         self.save()
 
@@ -221,6 +226,7 @@ class GameState(object):
         self.state[channel]["winner"] = winner
         self.state[channel]["step"] = "waiting"
         self.state[channel]["emojirade"] = None
+        self.state[channel]["raw_emojirade"] = None
         self.save()
 
     def game_status(self, channel):

--- a/plusplusbot/tests/test_scenarios.py
+++ b/plusplusbot/tests/test_scenarios.py
@@ -13,6 +13,7 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["old_winner"] is None
         assert self.state["winner"] is None
         assert self.state["emojirade"] is None
+        assert self.state["raw_emojirade"] is None
         assert not self.scoreboard["scores"]
 
         self.send_event(self.events.new_game)
@@ -20,6 +21,7 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["old_winner"] == self.config.player_1
         assert self.state["winner"] == self.config.player_2
         assert self.state["emojirade"] is None
+        assert self.state["raw_emojirade"] is None
         assert not self.scoreboard["scores"]
 
         self.send_event(self.events.posted_emojirade)
@@ -27,6 +29,7 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["old_winner"] == self.config.player_1
         assert self.state["winner"] == self.config.player_2
         assert self.state["emojirade"] == [self.config.emojirade]
+        assert self.state["raw_emojirade"] == [self.config.emojirade]
         assert not self.scoreboard["scores"]
 
         self.send_event(self.events.posted_emoji)
@@ -34,6 +37,7 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["old_winner"] == self.config.player_1
         assert self.state["winner"] == self.config.player_2
         assert self.state["emojirade"] == [self.config.emojirade]
+        assert self.state["raw_emojirade"] == [self.config.emojirade]
         assert not self.scoreboard["scores"]
 
         self.send_event(self.events.correct_guess)
@@ -41,6 +45,7 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["old_winner"] == self.config.player_2
         assert self.state["winner"] == self.config.player_3
         assert self.state["emojirade"] is None
+        assert self.state["raw_emojirade"] is None
         assert list(self.scoreboard["scores"].keys()) == [self.config.player_3]
         assert self.scoreboard["scores"][self.config.player_3] == 1
         assert (self.config.channel, f"<@{self.config.player_3}>++") in self.responses
@@ -51,6 +56,7 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["old_winner"] is None
         assert self.state["winner"] is None
         assert self.state["emojirade"] is None
+        assert self.state["raw_emojirade"] is None
         assert not self.scoreboard["scores"]
 
         self.send_event(self.events.new_game)
@@ -58,6 +64,7 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["old_winner"] == self.config.player_1
         assert self.state["winner"] == self.config.player_2
         assert self.state["emojirade"] is None
+        assert self.state["raw_emojirade"] is None
         assert not self.scoreboard["scores"]
 
         self.send_event(self.events.posted_emojirade)
@@ -65,6 +72,7 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["old_winner"] == self.config.player_1
         assert self.state["winner"] == self.config.player_2
         assert self.state["emojirade"] == [self.config.emojirade]
+        assert self.state["raw_emojirade"] == [self.config.emojirade]
         assert not self.scoreboard["scores"]
 
         self.send_event(self.events.posted_emoji)
@@ -72,6 +80,7 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["old_winner"] == self.config.player_1
         assert self.state["winner"] == self.config.player_2
         assert self.state["emojirade"] == [self.config.emojirade]
+        assert self.state["raw_emojirade"] == [self.config.emojirade]
         assert not self.scoreboard["scores"]
 
         self.send_event(self.events.incorrect_guess)
@@ -79,6 +88,7 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["old_winner"] == self.config.player_1
         assert self.state["winner"] == self.config.player_2
         assert self.state["emojirade"] == [self.config.emojirade]
+        assert self.state["raw_emojirade"] == [self.config.emojirade]
         assert not self.scoreboard["scores"]
 
         self.send_event(self.events.manual_award)
@@ -86,6 +96,7 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["old_winner"] == self.config.player_2
         assert self.state["winner"] == self.config.player_3
         assert self.state["emojirade"] is None
+        assert self.state["raw_emojirade"] is None
         assert list(self.scoreboard["scores"].keys()) == [self.config.player_3]
         assert self.scoreboard["scores"][self.config.player_3] == 1
 
@@ -211,12 +222,14 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["old_winner"] == self.config.player_1
         assert self.state["winner"] == self.config.player_2
         assert self.state["emojirade"] == [self.config.emojirade]
+        assert self.state["raw_emojirade"] == [self.config.emojirade]
 
         self.send_event(self.events.correct_guess)
         assert self.state["step"] == "waiting"
         assert self.state["old_winner"] == self.config.player_2
         assert self.state["winner"] == self.config.player_3
         assert self.state["emojirade"] is None
+        assert self.state["raw_emojirade"] is None
         assert (self.config.channel, f"<@{self.config.player_3}>++") in self.responses
         assert any(
             self.config.channel == channel
@@ -231,6 +244,7 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["old_winner"] == self.config.player_2
         assert self.state["winner"] == self.config.player_3
         assert self.state["emojirade"] == [emojirade]
+        assert self.state["raw_emojirade"] == [emojirade]
 
         override = {"user": self.config.player_3}
         self.send_event({**self.events.posted_emoji, **override})
@@ -238,6 +252,7 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["old_winner"] == self.config.player_2
         assert self.state["winner"] == self.config.player_3
         assert self.state["emojirade"] == [emojirade]
+        assert self.state["raw_emojirade"] == [emojirade]
 
         override = {"user": self.config.player_1, "text": emojirade}
         self.send_event({**self.events.correct_guess, **override})
@@ -245,6 +260,7 @@ class TestBotScenarios(EmojiradeBotTester):
         assert self.state["old_winner"] == self.config.player_3
         assert self.state["winner"] == self.config.player_1
         assert self.state["emojirade"] is None
+        assert self.state["raw_emojirade"] is None
         assert (self.config.channel, f"<@{self.config.player_1}>++") in self.responses
         assert any(
             self.config.channel == channel
@@ -261,17 +277,20 @@ class TestBotScenarios(EmojiradeBotTester):
         self.send_event({**self.events.posted_emojirade, **override})
         assert self.state["step"] == "provided"
         assert self.state["emojirade"] == ["foo", "bar"]
+        assert self.state["raw_emojirade"] == ["foo", "bar"]
         assert not self.scoreboard["scores"]
 
         self.send_event(self.events.posted_emoji)
         assert self.state["step"] == "guessing"
         assert self.state["emojirade"] == ["foo", "bar"]
+        assert self.state["raw_emojirade"] == ["foo", "bar"]
         assert not self.scoreboard["scores"]
 
         override = {"text": "foo"}
         self.send_event({**self.events.correct_guess, **override})
         assert self.state["step"] == "waiting"
         assert self.state["emojirade"] is None
+        assert self.state["raw_emojirade"] is None
 
         # Check alternative B ('bar')
         self.reset_and_transition_to("waiting")
@@ -280,17 +299,20 @@ class TestBotScenarios(EmojiradeBotTester):
         self.send_event({**self.events.posted_emojirade, **override})
         assert self.state["step"] == "provided"
         assert self.state["emojirade"] == ["foo", "bar"]
+        assert self.state["raw_emojirade"] == ["foo", "bar"]
         assert not self.scoreboard["scores"]
 
         self.send_event(self.events.posted_emoji)
         assert self.state["step"] == "guessing"
         assert self.state["emojirade"] == ["foo", "bar"]
+        assert self.state["raw_emojirade"] == ["foo", "bar"]
         assert not self.scoreboard["scores"]
 
         override = {"text": "bar"}
         self.send_event({**self.events.correct_guess, **override})
         assert self.state["step"] == "waiting"
         assert self.state["emojirade"] is None
+        assert self.state["raw_emojirade"] is None
 
     def test_scott_factor_exceeded(self):
         """ Performs tests for guesses exceeding the scott factor """
@@ -336,10 +358,13 @@ class TestBotScenarios(EmojiradeBotTester):
         """ Test that the sanitize_text helper works as expected """
         self.reset_and_transition_to("waiting")
 
-        override = {"text": u'emojirade   Späce : THE\t\t\tfinal\v- f_r_ö_n+t/ier'}
+        raw_rade = u"Späce : THE\t\t\tfinal\v- f_r_ö_n+t/ier"
+        override = {"text": f"emojirade   {raw_rade}"}
         self.send_event({**self.events.posted_emojirade, **override})
+
         assert self.state["step"] == "provided"
         assert self.state["emojirade"] == ["space the final frontier"]
+        assert self.state["raw_emojirade"] == [raw_rade]
 
     def test_emoji_detection(self):
         """ Performs tests to ensure when an emoji is posted the game progresses in state """


### PR DESCRIPTION
This fixes #111 

We take into consideration the raw rade may contain un-escape chars, so we remove them on the display layer before printing it out!